### PR TITLE
Bugfix in Dockerfile to match bugfix in run_tests.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ RUN pip install poetry \
 
 COPY . /dictionaryutils
 
-CMD cd /dictionary; rm -rf build dictionaryutils dist gdcdictionary.egg-info; python setup.py install --force && cp -r /dictionaryutils . && cd /dictionary/dictionaryutils; nosetests -s -v; export SUCCESS=$?; cd ..; rm -rf build dictionaryutils dist gdcdictionary.egg-info; exit $SUCCESS
+CMD cd /dictionary; rm -rf build dictionaryutils dist gdcdictionary.egg-info; python setup.py install --force && cp -r /dictionaryutils . && cd /dictionary/dictionaryutils; pip uninstall -y gen3dictionary; nosetests -s -v; export SUCCESS=$?; cd ..; rm -rf build dictionaryutils dist gdcdictionary.egg-info; exit $SUCCESS


### PR DESCRIPTION
This fix circumvents the problem described and fixed in run_tests.sh
https://github.com/uc-cdis/dictionaryutils/blob/master/run_tests.sh#L17
Tests performed with that docker image were always run against a package instead of a mounted dictionary directory, uninstalling that package before we run tests fixes that issue.